### PR TITLE
Add Flask-SQLAlchemy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 flask
+flask-sqlalchemy


### PR DESCRIPTION
## Summary

Added `flask-sqlalchemy` to `requirements.txt`.

## Reason

The project imports `flask_sqlalchemy` in `models.py`, but this dependency was not listed in `requirements.txt`. Without it, a fresh local setup fails when running `python app.py` with:

```text
ModuleNotFoundError: No module named 'flask_sqlalchemy'