### PR TITLE
Add Create Post catch details and posts API integration

### DIFF
--- a/app/api/posts.py
+++ b/app/api/posts.py
@@ -5,7 +5,7 @@ GET  /api/posts          — list posts (with ?category= and ?q= filters)
 POST /api/posts          — create a new post (TODO)
 
 ===== Map (Chrommanito) =====
-GET  /api/posts/map      — posts that have location data (TODO)
+GET  /api/posts/map      — posts that have location data
 
 ===== Legacy (temporary — remove after DB migration) =====
 GET  /api/feed-posts     — mock feed data
@@ -14,14 +14,24 @@ GET  /api/saved-posts    — mock saved posts
 """
 
 import json
+import base64
+import re
+import uuid
 from pathlib import Path
 
-from flask import jsonify
-from app import app
+from flask import jsonify, request
+from flask_login import current_user
+from sqlalchemy import or_
+
+from app import app, db
+from app.models import Post, PostImage, User
 
 # ---------- Temporary mock-data paths (remove after DB migration) ----------
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 FEED_POSTS_FILE = BASE_DIR / "mockdata" / "feedPosts.json"
+ALLOWED_CATEGORIES = {"Catch Report", "Gear Review", "Question", "General"}
+DATA_URL_RE = re.compile(r"^data:image/(png|jpe?g|gif|webp);base64,(.+)$", re.I)
+MAX_INLINE_IMAGE_BYTES = 2 * 1024 * 1024
 
 
 @app.route("/api/feed-posts")
@@ -50,17 +60,193 @@ def api_saved_posts():
     return jsonify(data)
 
 
-# ===== CRUD (Felix) — TODO =============================================
+def _get_current_user_id():
+    """Return the active user, falling back to the seeded demo user in dev."""
+    if current_user and current_user.is_authenticated:
+        return current_user.id
+    return 1
 
-# @app.route("/api/posts")
-# def api_list_posts(): ...
 
-# @app.route("/api/posts", methods=["POST"])
-# @login_required
-# def api_create_post(): ...
+def _clean_optional_text(value, max_length):
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("Optional text fields must be strings.")
+    value = value.strip()
+    if not value:
+        return None
+    if len(value) > max_length:
+        raise ValueError(f"Text field cannot exceed {max_length} characters.")
+    return value
+
+
+def _clean_optional_float(value, field_name):
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a number.") from exc
+
+
+def _store_image_url_or_data_url(value):
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("Each photo must be a non-empty string.")
+
+    value = value.strip()
+    match = DATA_URL_RE.match(value)
+    if not match:
+        if len(value) > 255:
+            raise ValueError("Photo URL is too long.")
+        return value
+
+    extension = "jpg" if match.group(1).lower() in {"jpg", "jpeg"} else match.group(1).lower()
+    try:
+        image_bytes = base64.b64decode(match.group(2), validate=True)
+    except ValueError as exc:
+        raise ValueError("Photo data is not valid base64.") from exc
+
+    if len(image_bytes) > MAX_INLINE_IMAGE_BYTES:
+        raise ValueError("Each uploaded image must be under 2 MB.")
+
+    upload_dir = Path(app.config["UPLOAD_FOLDER"])
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    filename = f"post-{uuid.uuid4().hex}.{extension}"
+    (upload_dir / filename).write_bytes(image_bytes)
+    return f"/static/uploads/{filename}"
+
+
+def _serialize_post(post):
+    images = sorted(post.images, key=lambda image: image.display_order or 0)
+
+    return {
+        "id": post.id,
+        "author": {
+            "userId": post.user.id if post.user else None,
+            "username": post.user.username if post.user else "Unknown User",
+            "avatarUrl": post.user.avatar_url if post.user else None,
+        },
+        "content": post.content,
+        "photos": [image.image_url for image in images],
+        "category": post.category,
+        "species": post.species,
+        "weightKg": post.weight_kg,
+        "bait": post.bait,
+        "locationName": post.location_name,
+        "latitude": post.latitude,
+        "longitude": post.longitude,
+        "metrics": {
+            "likes": len(post.likes),
+            "comments": len(post.comments),
+        },
+        "createdAt": post.created_at.isoformat() if post.created_at else None,
+    }
+
+
+# ===== CRUD (Felix) =====================================================
+
+
+@app.route("/api/posts")
+def api_list_posts():
+    """Return database posts in the unified Feed/Create Post JSON shape."""
+    category = request.args.get("category")
+    search = (request.args.get("q") or "").strip()
+
+    query = Post.query
+
+    if category and category != "All":
+        query = query.filter(Post.category == category)
+
+    if search:
+        pattern = f"%{search}%"
+        query = query.join(User).filter(
+            or_(
+                Post.content.ilike(pattern),
+                Post.species.ilike(pattern),
+                Post.location_name.ilike(pattern),
+                User.username.ilike(pattern),
+            )
+        )
+
+    posts = query.order_by(Post.created_at.desc()).all()
+    return jsonify([_serialize_post(post) for post in posts])
+
+
+@app.route("/api/posts", methods=["POST"])
+def api_create_post():
+    """Create a post from the Create Post page."""
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "Request body must be valid JSON."}), 400
+
+    content = data.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return jsonify({"error": "Content is required."}), 400
+
+    category = data.get("category")
+    if category not in ALLOWED_CATEGORIES:
+        return jsonify({"error": "Please select a valid category."}), 400
+
+    user_id = _get_current_user_id()
+    if db.session.get(User, user_id) is None:
+        return jsonify({"error": "Please log in before creating a post."}), 401
+
+    try:
+        weight_kg = _clean_optional_float(data.get("weightKg"), "weightKg")
+        if weight_kg is not None and weight_kg < 0:
+            return jsonify({"error": "weightKg cannot be negative."}), 400
+
+        latitude = _clean_optional_float(data.get("latitude"), "latitude")
+        longitude = _clean_optional_float(data.get("longitude"), "longitude")
+
+        post = Post(
+            user_id=user_id,
+            content=content.strip(),
+            category=category,
+            species=_clean_optional_text(data.get("species"), 120),
+            weight_kg=weight_kg,
+            bait=_clean_optional_text(data.get("bait"), 120),
+            location_name=_clean_optional_text(data.get("locationName"), 120),
+            latitude=latitude,
+            longitude=longitude,
+        )
+
+        photos = data.get("photos") or []
+        if not isinstance(photos, list):
+            return jsonify({"error": "photos must be an array."}), 400
+        if len(photos) > 8:
+            return jsonify({"error": "You can upload up to 8 photos."}), 400
+
+        image_urls = [_store_image_url_or_data_url(photo) for photo in photos]
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    db.session.add(post)
+    db.session.flush()
+
+    for index, image_url in enumerate(image_urls):
+        db.session.add(PostImage(
+            post_id=post.id,
+            image_url=image_url,
+            display_order=index,
+        ))
+
+    db.session.commit()
+
+    return jsonify(_serialize_post(post)), 201
+
 
 
 # ===== Map (Chrommanito) — TODO ========================================
 
-# @app.route("/api/posts/map")
-# def api_map_posts(): ...
+@app.route("/api/posts/map")
+def api_map_posts():
+    """Return posts that can be shown as map markers."""
+    posts = (
+        Post.query
+        .filter(Post.latitude.isnot(None), Post.longitude.isnot(None))
+        .order_by(Post.created_at.desc())
+        .all()
+    )
+    return jsonify([_serialize_post(post) for post in posts])

--- a/app/static/css/create-post.css
+++ b/app/static/css/create-post.css
@@ -51,6 +51,18 @@ body {
   font-family: inherit;
 }
 
+.text-input,
+.location-input,
+.category-select {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #dbdbdb;
+  font-size: 14px;
+  font-family: inherit;
+  background: white;
+}
+
 .form-field input[type="file"] {
   font-size: 14px;
 }
@@ -104,15 +116,36 @@ body {
 }
 
 /* Input fields */
-.location-input,
-.category-select {
-  width: 100%;
-  padding: 10px 12px;
-  border-radius: 8px;
+.catch-details {
+  margin: 0 0 16px;
   border: 1px solid #dbdbdb;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.catch-details summary {
+  padding: 12px;
+  cursor: pointer;
   font-size: 14px;
-  font-family: inherit;
-  background: white;
+  font-weight: 600;
+}
+
+.catch-details__fields {
+  padding: 0 12px 4px;
+}
+
+.location-map {
+  width: 100%;
+  height: 260px;
+  border: 1px solid #dbdbdb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.selected-coordinates {
+  color: #666;
+  font-size: 12px;
+  margin: -4px 0 0;
 }
 
 /* Submit button */

--- a/app/static/css/feed.css
+++ b/app/static/css/feed.css
@@ -73,6 +73,21 @@ body {
   white-space: pre-line;
 }
 
+.feed-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0 10px 10px;
+}
+
+.feed-meta span {
+  background: #efefef;
+  border-radius: 999px;
+  color: #262626;
+  font-size: 12px;
+  padding: 5px 8px;
+}
+
 
 .feed-image-grid {
   display: grid;

--- a/app/static/js/create-post.js
+++ b/app/static/js/create-post.js
@@ -2,8 +2,44 @@ const imageInput = document.getElementById("imageInput");
 const imagePreview = document.getElementById("imagePreview");
 
 let uploadedImages = []; // base64 strings
-const MAX_IMAGE_BYTES = 500 * 1024;
-const MAX_TOTAL_IMAGE_CHARS = 2 * 1024 * 1024;
+let selectedLatitude = null;
+let selectedLongitude = null;
+const MAX_IMAGE_BYTES = 2 * 1024 * 1024;
+const MAX_TOTAL_IMAGE_CHARS = 10 * 1024 * 1024;
+
+function initLocationMap() {
+  const mapEl = document.getElementById("locationMap");
+  if (!mapEl || typeof L === "undefined") return;
+
+  const coordinatesEl = document.getElementById("selectedCoordinates");
+  const locationInput = document.getElementById("postLocation");
+  const map = L.map(mapEl).setView([-31.9523, 115.8613], 12);
+  let marker = null;
+
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    attribution: "&copy; OpenStreetMap contributors",
+    maxZoom: 19
+  }).addTo(map);
+
+  map.on("click", (event) => {
+    selectedLatitude = Number(event.latlng.lat.toFixed(6));
+    selectedLongitude = Number(event.latlng.lng.toFixed(6));
+
+    if (marker) {
+      marker.setLatLng(event.latlng);
+    } else {
+      marker = L.marker(event.latlng).addTo(map);
+    }
+
+    coordinatesEl.textContent = `${selectedLatitude}, ${selectedLongitude}`;
+
+    if (!locationInput.value.trim()) {
+      locationInput.value = `Map point (${selectedLatitude}, ${selectedLongitude})`;
+    }
+  });
+}
+
+initLocationMap();
 
 /* Image upload preview */
 imageInput.addEventListener("change", () => {
@@ -18,7 +54,7 @@ imageInput.addEventListener("change", () => {
 
   files.forEach(file => {
     if (file.size > MAX_IMAGE_BYTES) {
-      alert(`${file.name} is too large. Please choose images under 500KB.`);
+      alert(`${file.name} is too large. Please choose images under 2MB.`);
       return;
     }
 
@@ -44,10 +80,15 @@ imageInput.addEventListener("change", () => {
 });
 
 /* Submit post */
-document.querySelector(".post-btn").addEventListener("click", () => {
+document.querySelector(".post-btn").addEventListener("click", async () => {
+  const submitButton = document.querySelector(".post-btn");
   const content = document.querySelector(".post-text").value.trim();
-  const postLocation = document.querySelector(".location-input").value.trim();
+  const locationName = document.querySelector(".location-input").value.trim();
   const category = document.querySelector(".category-select").value;
+  const species = document.getElementById("postSpecies").value.trim();
+  const weightValue = document.getElementById("postWeight").value;
+  const bait = document.getElementById("postBait").value.trim();
+  const weightKg = weightValue ? Number(weightValue) : null;
 
   if (!content) {
     alert("Please write something before posting.");
@@ -59,29 +100,49 @@ document.querySelector(".post-btn").addEventListener("click", () => {
     return;
   }
 
-  const newPost = {
-    id: Date.now(),
-    username: "You",
-    avatar: "https://i.pravatar.cc/150?img=10",
-    time: "Just now",
-    content: content + (postLocation ? `\n📍 ${postLocation}` : ""),
-    images: uploadedImages,
-    likes: 0,
-    comments: 0,
-    tags: [category]
-  };
-
-  const existing = JSON.parse(localStorage.getItem("userPosts") || "[]");
-  existing.unshift(newPost);
-
-  try {
-    localStorage.setItem("userPosts", JSON.stringify(existing));
-  } catch (err) {
-    console.error("Failed to save post:", err);
-    alert("Unable to save this post. Please use smaller images or remove some images.");
+  if (weightKg !== null && (Number.isNaN(weightKg) || weightKg < 0)) {
+    alert("Please enter a valid weight.");
     return;
   }
 
-  alert("Post submitted!");
-  location.href = "../feed/feed.html";
+  const postData = {
+    content,
+    photos: uploadedImages,
+    category,
+    species: species || null,
+    weightKg,
+    bait: bait || null,
+    locationName: locationName || null,
+    latitude: selectedLatitude,
+    longitude: selectedLongitude
+  };
+
+  submitButton.disabled = true;
+  submitButton.textContent = "Posting...";
+
+  try {
+    const response = await fetch("/api/posts", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(postData)
+    });
+
+    const result = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      alert(result.error || "Unable to submit this post. Please try again.");
+      return;
+    }
+
+    alert("Post submitted!");
+    location.href = submitButton.dataset.feedUrl || "/";
+  } catch (err) {
+    console.error("Failed to submit post:", err);
+    alert("Unable to submit this post. Please try again.");
+  } finally {
+    submitButton.disabled = false;
+    submitButton.textContent = "Post";
+  }
 });

--- a/app/static/js/feed.js
+++ b/app/static/js/feed.js
@@ -2,6 +2,60 @@ let allPosts = [];
 let currentSearch = "";
 let currentTag = "All";
 
+function formatTime(value) {
+  if (!value) return "";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric"
+  });
+}
+
+function formatWeight(value) {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value === "number") return `${value} kg`;
+  return String(value);
+}
+
+function normalizePost(post) {
+  const catchDetails = post.catchDetails || {};
+  const location = catchDetails.location || {};
+  const tags = Array.isArray(post.tags) ? post.tags : [];
+  const category = post.category || (
+    tags.includes("Gear") ? "Gear Review" :
+    tags.includes("Question") ? "Question" :
+    tags.length > 0 ? "Catch Report" :
+    "General"
+  );
+
+  return {
+    id: post.id,
+    author: post.author || {
+      userId: post.userId || "",
+      username: post.username || "Unknown User",
+      avatarUrl: post.avatar || ""
+    },
+    content: post.content || "",
+    photos: Array.isArray(post.photos) ? post.photos : (Array.isArray(post.images) ? post.images : []),
+    category,
+    species: post.species ?? catchDetails.species ?? null,
+    weightKg: post.weightKg ?? catchDetails.weight ?? null,
+    bait: post.bait ?? catchDetails.bait ?? null,
+    locationName: post.locationName ?? location.name ?? null,
+    latitude: post.latitude ?? location.latitude ?? null,
+    longitude: post.longitude ?? location.longitude ?? null,
+    metrics: {
+      likes: post.metrics?.likes ?? post.likes ?? 0,
+      comments: post.metrics?.comments ?? post.metrics?.commentsCount ?? post.comments ?? 0
+    },
+    createdAt: post.createdAt || post.time || ""
+  };
+}
+
 function loadPosts(path) {
   return fetch(path).then(res => {
     if (!res.ok) {
@@ -11,17 +65,21 @@ function loadPosts(path) {
   });
 }
 
-/* Load data: merge mock JSON + localStorage posts */
-loadPosts("/api/feed-posts")
+/* Load data: prefer database posts, then fall back to legacy mock JSON. */
+loadPosts("/api/posts")
+  .catch(err => {
+    console.warn("Failed to load database posts, falling back to mock data:", err);
+    return loadPosts("/api/feed-posts");
+  })
   .then(jsonPosts => {
     const localPosts = JSON.parse(localStorage.getItem("userPosts") || "[]");
-    allPosts = [...localPosts, ...jsonPosts];
+    allPosts = [...localPosts, ...jsonPosts].map(normalizePost);
     renderPosts(allPosts);
   })
   .catch(err => {
     console.error("Failed to load posts:", err);
     const localPosts = JSON.parse(localStorage.getItem("userPosts") || "[]");
-    allPosts = localPosts;
+    allPosts = localPosts.map(normalizePost);
     renderPosts(allPosts);
   });
 
@@ -46,26 +104,28 @@ function renderPosts(posts) {
     const card = document.createElement("div");
     card.className = "feed-card";
 
-    const images = Array.isArray(post.images) ? post.images : [];
+    const images = Array.isArray(post.photos) ? post.photos : [];
+    const author = post.author || {};
+    const metrics = post.metrics || {};
 
     const header = document.createElement("div");
     header.className = "feed-header";
 
     const avatar = document.createElement("img");
     avatar.className = "feed-avatar";
-    avatar.src = post.avatar || "";
+    avatar.src = author.avatarUrl || "";
     avatar.alt = "avatar";
 
     const headerText = document.createElement("div");
 
     const username = document.createElement("div");
     username.className = "feed-username";
-    username.textContent = post.username || "";
+    username.textContent = author.username || "";
 
     const time = document.createElement("div");
     time.style.fontSize = "12px";
     time.style.color = "gray";
-    time.textContent = post.time || "";
+    time.textContent = formatTime(post.createdAt);
 
     headerText.append(username, time);
     header.append(avatar, headerText);
@@ -75,6 +135,27 @@ function renderPosts(posts) {
     content.textContent = post.content || "";
 
     card.append(header, content);
+
+    const details = [
+      post.category,
+      post.species,
+      formatWeight(post.weightKg),
+      post.bait ? `Bait: ${post.bait}` : null,
+      post.locationName
+    ].filter(Boolean);
+
+    if (details.length > 0) {
+      const meta = document.createElement("div");
+      meta.className = "feed-meta";
+
+      details.forEach(detail => {
+        const item = document.createElement("span");
+        item.textContent = detail;
+        meta.appendChild(item);
+      });
+
+      card.appendChild(meta);
+    }
 
     if (images.length > 0) {
       const imageGrid = document.createElement("div");
@@ -103,7 +184,7 @@ function renderPosts(posts) {
 
     const likeCount = document.createElement("span");
     likeCount.className = "like-count";
-    likeCount.textContent = post.likes ?? 0;
+    likeCount.textContent = metrics.likes ?? 0;
     likeButton.appendChild(likeCount);
 
     const commentButton = document.createElement("button");
@@ -115,7 +196,7 @@ function renderPosts(posts) {
 
     const commentCount = document.createElement("span");
     commentCount.className = "comment-count";
-    commentCount.textContent = post.comments ?? 0;
+    commentCount.textContent = metrics.comments ?? 0;
     commentButton.appendChild(commentCount);
 
     footer.append(likeButton, commentButton);
@@ -130,13 +211,13 @@ function renderPosts(posts) {
       if (this.classList.contains("liked")) {
         this.classList.remove("liked");
         this.setAttribute("aria-pressed", "false");
-        post.likes = Math.max(0, (post.likes ?? 1) - 1);
+        post.metrics.likes = Math.max(0, (post.metrics.likes ?? 1) - 1);
       } else {
         this.classList.add("liked");
         this.setAttribute("aria-pressed", "true");
-        post.likes = (post.likes ?? 0) + 1;
+        post.metrics.likes = (post.metrics.likes ?? 0) + 1;
       }
-      span.textContent = post.likes;
+      span.textContent = post.metrics.likes;
     });
 
     /* Comment button */
@@ -146,8 +227,8 @@ function renderPosts(posts) {
         const span = this.querySelector(".comment-count");
         const post = allPosts.find(p => String(p.id) === String(this.dataset.id));
         if (!post) return;
-        post.comments = (post.comments ?? 0) + 1;
-        span.textContent = post.comments;
+        post.metrics.comments = (post.metrics.comments ?? 0) + 1;
+        span.textContent = post.metrics.comments;
       }
     });
 
@@ -161,14 +242,16 @@ function applyFilters() {
 
   if (currentTag !== "All") {
     filtered = filtered.filter(post =>
-      Array.isArray(post.tags) && post.tags.includes(currentTag)
+      post.category === currentTag
     );
   }
 
   if (currentSearch) {
     filtered = filtered.filter(post =>
       (post.content || "").toLowerCase().includes(currentSearch) ||
-      (post.username || "").toLowerCase().includes(currentSearch)
+      (post.author?.username || "").toLowerCase().includes(currentSearch) ||
+      (post.species || "").toLowerCase().includes(currentSearch) ||
+      (post.locationName || "").toLowerCase().includes(currentSearch)
     );
   }
 

--- a/app/templates/create_post.html
+++ b/app/templates/create_post.html
@@ -3,6 +3,7 @@
 {% block title %}Create Post | CatchLog{% endblock %}
 
 {% block styles %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
 <link rel="stylesheet" href="{{ url_for('static', filename='css/create-post.css') }}" />
 {% endblock %}
 
@@ -43,20 +44,67 @@
   </div>
 
   <div class="form-field">
+    <label>Map Point</label>
+    <div id="locationMap" class="location-map"></div>
+    <p id="selectedCoordinates" class="selected-coordinates">
+      No map point selected.
+    </p>
+  </div>
+
+  <div class="form-field">
     <label for="postCategory">Category</label>
     <select id="postCategory" class="category-select">
       <option disabled selected>Select Category</option>
-      <option>Bass</option>
-      <option>Trout</option>
-      <option>Gear</option>
+      <option>Catch Report</option>
+      <option>Gear Review</option>
       <option>Question</option>
+      <option>General</option>
     </select>
   </div>
 
-  <button class="post-btn">Post</button>
+  <details class="catch-details">
+    <summary>Catch Details</summary>
+
+    <div class="catch-details__fields">
+      <div class="form-field">
+        <label for="postSpecies">Species</label>
+        <input
+          type="text"
+          id="postSpecies"
+          class="text-input"
+          placeholder="e.g. Largemouth Bass"
+        />
+      </div>
+
+      <div class="form-field">
+        <label for="postWeight">Weight (kg)</label>
+        <input
+          type="number"
+          id="postWeight"
+          class="text-input"
+          min="0"
+          step="0.01"
+          placeholder="e.g. 2.04"
+        />
+      </div>
+
+      <div class="form-field">
+        <label for="postBait">Bait</label>
+        <input
+          type="text"
+          id="postBait"
+          class="text-input"
+          placeholder="e.g. Plastic Worm"
+        />
+      </div>
+    </div>
+  </details>
+
+  <button class="post-btn" data-feed-url="{{ url_for('feed') }}">Post</button>
 </div>
 {% endblock %}
 
 {% block scripts %}
+<script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="{{ url_for('static', filename='js/create-post.js') }}"></script>
 {% endblock %}

--- a/app/templates/feed.html
+++ b/app/templates/feed.html
@@ -24,10 +24,10 @@
 <!-- Tag filter -->
 <div class="tag-filter">
   <button class="tag active">All</button>
-  <button class="tag">Bass</button>
-  <button class="tag">Trout</button>
-  <button class="tag">Gear</button>
+  <button class="tag">Catch Report</button>
+  <button class="tag">Gear Review</button>
   <button class="tag">Question</button>
+  <button class="tag">General</button>
 </div>
 
 <!-- Feed posts -->

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import os
 
 basedir = os.path.abspath(os.path.dirname(__file__))
+os.makedirs(os.path.join(basedir, "instance"), exist_ok=True)
 
 
 class Config:

--- a/mockdata/feedPosts.json
+++ b/mockdata/feedPosts.json
@@ -1,29 +1,51 @@
 [
   {
-    "id": 1,
-    "username": "MikeFishing",
-    "avatar": "https://i.pravatar.cc/150?img=1",
-    "time": "2 hours ago",
+    "id": 4,
+    "author": {
+      "userId": 2,
+      "username": "MikeFishing",
+      "avatarUrl": "https://i.pravatar.cc/150?img=1"
+    },
     "content": "Caught this bass near the lake this morning!",
-    "images": [
+    "photos": [
       "https://picsum.photos/300/300?random=1",
       "https://picsum.photos/300/300?random=2"
     ],
-    "likes": 12,
-    "comments": 4,
-    "tags": ["Bass", "Freshwater"]
+    "category": "Catch Report",
+    "species": "Bass",
+    "weightKg": null,
+    "bait": null,
+    "locationName": "Local lake",
+    "latitude": null,
+    "longitude": null,
+    "metrics": {
+      "likes": 12,
+      "comments": 4
+    },
+    "createdAt": "2026-04-01T08:00:00Z"
   },
   {
-    "id": 2,
-    "username": "AnnaReels",
-    "avatar": "https://i.pravatar.cc/150?img=2",
-    "time": "5 hours ago",
+    "id": 5,
+    "author": {
+      "userId": 3,
+      "username": "AnnaReels",
+      "avatarUrl": "https://i.pravatar.cc/150?img=2"
+    },
     "content": "Any good rod recommendations?",
-    "images": [
+    "photos": [
       "https://picsum.photos/300/300?random=3"
     ],
-    "likes": 5,
-    "comments": 2,
-    "tags": ["Gear", "Question"]
+    "category": "Question",
+    "species": null,
+    "weightKg": null,
+    "bait": null,
+    "locationName": null,
+    "latitude": null,
+    "longitude": null,
+    "metrics": {
+      "likes": 5,
+      "comments": 2
+    },
+    "createdAt": "2026-04-01T11:00:00Z"
   }
 ]

--- a/mockdata/myPosts.json
+++ b/mockdata/myPosts.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": "post_001",
+    "id": 1,
     "author": {
-      "userId": "user_101",
+      "userId": 1,
       "username": "BassHunter99",
       "avatarUrl": "https://images.pexels.com/photos/1036622/pexels-photo-1036622.jpeg"
     },
@@ -10,26 +10,23 @@
     "photos": [
       "https://images.pexels.com/photos/3220790/pexels-photo-3220790.jpeg"
     ],
-    "catchDetails": {
-      "species": "Largemouth Bass",
-      "weight": "4.5 lbs",
-      "bait": "Plastic Worm",
-      "location": {
-        "name": "Swan River, Perth",
-        "latitude": -31.95,
-        "longitude": 115.86
-      }
-    },
+    "category": "Catch Report",
+    "species": "Largemouth Bass",
+    "weightKg": 2.04,
+    "bait": "Plastic Worm",
+    "locationName": "Swan River, Perth",
+    "latitude": -31.95,
+    "longitude": 115.86,
     "metrics": {
       "likes": 24,
-      "commentsCount": 5
+      "comments": 5
     },
     "createdAt": "2026-03-30T08:30:00Z"
   },
   {
-    "id": "post_002",
+    "id": 2,
     "author": {
-      "userId": "user_102",
+      "userId": 1,
       "username": "OceanExplorer",
       "avatarUrl": "https://images.pexels.com/photos/1181686/pexels-photo-1181686.jpeg"
     },
@@ -38,26 +35,23 @@
       "https://images.pexels.com/photos/2132007/pexels-photo-2132007.jpeg",
       "https://images.pexels.com/photos/17275414/pexels-photo-17275414.jpeg"
     ],
-    "catchDetails": {
-      "species": "Yellowfin Tuna",
-      "weight": "32 kg",
-      "bait": "Live Squid",
-      "location": {
-        "name": "Rottnest Island Trench",
-        "latitude": -32.0,
-        "longitude": 115.5
-      }
-    },
+    "category": "Catch Report",
+    "species": "Yellowfin Tuna",
+    "weightKg": 32,
+    "bait": "Live Squid",
+    "locationName": "Rottnest Island Trench",
+    "latitude": -32.0,
+    "longitude": 115.5,
     "metrics": {
       "likes": 156,
-      "commentsCount": 18
+      "comments": 18
     },
     "createdAt": "2026-03-31T06:15:00Z"
   },
   {
-    "id": "post_003",
+    "id": 3,
     "author": {
-      "userId": "user_103",
+      "userId": 1,
       "username": "QuietAngler",
       "avatarUrl": "https://images.pexels.com/photos/1222271/pexels-photo-1222271.jpeg"
     },
@@ -68,19 +62,16 @@
       "https://images.pexels.com/photos/17250336/pexels-photo-17250336.jpeg",
       "https://images.pexels.com/photos/17250336/pexels-photo-17250336.jpeg"
     ],
-    "catchDetails": {
-      "species": "Rainbow Trout",
-      "weight": "1.2 lbs",
-      "bait": "Fly",
-      "location": {
-        "name": "Serpentine Dam",
-        "latitude": -32.4,
-        "longitude": 116.1
-      }
-    },
+    "category": "Catch Report",
+    "species": "Rainbow Trout",
+    "weightKg": 0.54,
+    "bait": "Fly",
+    "locationName": "Serpentine Dam",
+    "latitude": -32.4,
+    "longitude": 116.1,
     "metrics": {
       "likes": 8,
-      "commentsCount": 1
+      "comments": 1
     },
     "createdAt": "2026-03-31T10:45:00Z"
   }

--- a/mockdata/savedPosts.json
+++ b/mockdata/savedPosts.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": "post_004",
+    "id": 6,
     "author": {
-      "userId": "user_205",
+      "userId": 4,
       "username": "GearJunkie",
       "avatarUrl": "https://images.pexels.com/photos/220453/pexels-photo-220453.jpeg"
     },
@@ -10,40 +10,38 @@
     "photos": [
       "https://images.pexels.com/photos/8536858/pexels-photo-8536858.jpeg"
     ],
-    "catchDetails": {
-      "species": null,
-      "weight": null,
-      "bait": "Stickbait",
-      "location": null
-    },
+    "category": "Gear Review",
+    "species": null,
+    "weightKg": null,
+    "bait": "Stickbait",
+    "locationName": null,
+    "latitude": null,
+    "longitude": null,
     "metrics": {
       "likes": 341,
-      "commentsCount": 56
+      "comments": 56
     },
     "createdAt": "2026-03-28T14:20:00Z"
   },
   {
-    "id": "post_005",
+    "id": 7,
     "author": {
-      "userId": "user_309",
+      "userId": 5,
       "username": "NightFisher",
       "avatarUrl": "https://images.pexels.com/photos/775358/pexels-photo-775358.jpeg"
     },
     "content": "Does anyone know a good spot for squidding around Fremantle during winter nights?",
     "photos": [],
-    "catchDetails": {
-      "species": "Squid",
-      "weight": null,
-      "bait": "Squid Jig",
-      "location": {
-        "name": "Fremantle Port",
-        "latitude": -32.05,
-        "longitude": 115.74
-      }
-    },
+    "category": "Question",
+    "species": "Squid",
+    "weightKg": null,
+    "bait": "Squid Jig",
+    "locationName": "Fremantle Port",
+    "latitude": -32.05,
+    "longitude": 115.74,
     "metrics": {
       "likes": 12,
-      "commentsCount": 4
+      "comments": 4
     },
     "createdAt": "2026-03-29T21:05:00Z"
   }

--- a/seed.py
+++ b/seed.py
@@ -35,6 +35,18 @@ def parse_weight(value: Optional[str]) -> Optional[float]:
     return float(match.group()) if match else None
 
 
+def get_location(post_data):
+    """Read location from the unified mock shape, with legacy fallback."""
+    catch_details = post_data.get("catchDetails") or {}
+    legacy_location = catch_details.get("location") or {}
+
+    return {
+        "name": post_data.get("locationName") or legacy_location.get("name"),
+        "latitude": post_data.get("latitude", legacy_location.get("latitude")),
+        "longitude": post_data.get("longitude", legacy_location.get("longitude")),
+    }
+
+
 with app.app_context():
     db.drop_all()
     db.create_all()
@@ -54,8 +66,9 @@ with app.app_context():
         posts_data = json.load(f)
 
     for post_data in posts_data:
-        catch_details = post_data.get("catchDetails", {})
-        location = catch_details.get("location", {})
+        catch_details = post_data.get("catchDetails") or {}
+        location = get_location(post_data)
+        weight_value = post_data.get("weightKg", catch_details.get("weight"))
 
         post = Post(
             user_id=demo_user.id,
@@ -63,10 +76,10 @@ with app.app_context():
             location_name=location.get("name"),
             latitude=location.get("latitude"),
             longitude=location.get("longitude"),
-            species=catch_details.get("species"),
-            weight_kg=parse_weight(catch_details.get("weight")),
-            bait=catch_details.get("bait"),
-            category=post_data.get("category"),
+            species=post_data.get("species", catch_details.get("species")),
+            weight_kg=parse_weight(weight_value),
+            bait=post_data.get("bait", catch_details.get("bait")),
+            category=post_data.get("category", "General"),
             created_at=parse_date(post_data.get("createdAt")),
         )
 


### PR DESCRIPTION
## Summary

- Added optional catch detail fields to Create Post:
  - species
  - weight
  - bait
- Separated `category` from `species`
- Updated Create Post to submit posts through `/api/posts`
- Implemented `GET /api/posts` and `POST /api/posts`
- Added coordinate selection support in Create Post
- Added `GET /api/posts/map` for future Map integration
- Standardized mock post JSON format
- Updated `seed.py` to read the new mock data shape
- Ensured the SQLite `instance/` directory is created automatically

## Testing

- Ran JS syntax checks for Create Post and Feed
- Ran Python compile checks
- Re-seeded the local database with `python seed.py`
- Verified `/api/posts` returns posts successfully
- Verified created posts save category, species, bait, weight, location, and coordinates
