### PR TITLE
fix: handle unauthenticated users for post interactions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ Route and model imports are placed at the **bottom** to avoid circular
 dependencies, following the recommended Flask package pattern.
 """
 
-from flask import Flask, render_template
+from flask import Flask, render_template, request, redirect, url_for, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_migrate import Migrate
@@ -37,6 +37,14 @@ def load_user(user_id):
     from app.models import User
 
     return db.session.get(User, int(user_id))
+
+
+@login_manager.unauthorized_handler
+def unauthorized():
+    """Return JSON 401 for API requests, redirect to login for page requests."""
+    if request.path.startswith("/api/"):
+        return jsonify({"error": "Authentication required"}), 401
+    return redirect(url_for("login"))
 
 
 # ---------------------------------------------------------------------------

--- a/app/static/css/post.css
+++ b/app/static/css/post.css
@@ -251,3 +251,21 @@
     transform: translateY(0);
   }
 }
+
+/* Login prompt for unauthenticated users */
+.login-prompt {
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 14px;
+  margin: 0;
+}
+
+.login-prompt a {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.login-prompt a:hover {
+  text-decoration: underline;
+}

--- a/app/static/js/post-card.js
+++ b/app/static/js/post-card.js
@@ -115,6 +115,12 @@ document.addEventListener("DOMContentLoaded", () => {
         icon.classList.add("fa-regular");
         button.classList.remove("action-btn--active");
         button.setAttribute("aria-pressed", "false");
+        
+        // Dispatch a custom event so the parent page (e.g., profile.js) can handle list updates
+        button.dispatchEvent(new CustomEvent("postSavedStateChanged", {
+          bubbles: true,
+          detail: { postId: button.dataset.postId, isSaved: false }
+        }));
       }
     }
   }

--- a/app/static/js/post-card.js
+++ b/app/static/js/post-card.js
@@ -59,6 +59,13 @@ document.addEventListener("DOMContentLoaded", () => {
         return;
       }
   
+      // Safety: if response is not JSON (e.g. HTML login redirect), go to login
+      const contentType = response.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        window.location.href = "/login";
+        return;
+      }
+
       const data = await response.json();
       updateButtonUI(button, type, data);
   

--- a/app/static/js/post.js
+++ b/app/static/js/post.js
@@ -59,6 +59,13 @@ async function handleCommentSubmit(event) {
       throw new Error(errData.error || `Failed to post comment: ${response.statusText}`);
     }
     
+    // Safety: if response is not JSON (e.g. HTML login redirect), go to login
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("application/json")) {
+      window.location.href = "/login";
+      return;
+    }
+
     const newComment = await response.json();
     
     // Clear input
@@ -148,6 +155,11 @@ async function handleCommentDelete(button) {
     const response = await fetch(`/api/posts/${postId}/comments/${commentId}`, {
       method: "DELETE"
     });
+
+    if (response.status === 401) {
+      window.location.href = "/login";
+      return;
+    }
 
     if (response.status === 403) {
       alert("You can only delete your own comments.");

--- a/app/static/js/profile.js
+++ b/app/static/js/profile.js
@@ -138,4 +138,30 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
   }
+
+  // ── Decoupled Post Card Event Listener ──
+  // Listen for custom events dispatched by the post-card component
+  document.addEventListener("postSavedStateChanged", (e) => {
+    const { isSaved } = e.detail;
+    if (!isSaved) {
+      // Find the card that triggered the event
+      const postCard = e.target.closest(".post-card");
+      if (!postCard) return;
+
+      // Only animate and remove if the card is inside the "Saved Posts" tab
+      const savedPostsTab = postCard.closest("#saved-posts");
+      if (savedPostsTab) {
+        postCard.style.transition = "opacity 0.3s ease, transform 0.3s ease";
+        postCard.style.opacity = "0";
+        postCard.style.transform = "scale(0.95)";
+        setTimeout(() => {
+          postCard.remove();
+          // Show empty state if no posts left
+          if (!savedPostsTab.querySelector(".post-card")) {
+            savedPostsTab.innerHTML = '<p class="empty-state">No saved posts to show.</p>';
+          }
+        }, 300);
+      }
+    }
+  });
 });

--- a/app/templates/components/_post_card.html
+++ b/app/templates/components/_post_card.html
@@ -80,9 +80,8 @@
   {# ── Footer: Actions ── #}
   {% if show_actions %}
   <div class="post-card__actions">
-    {# We determine if the current user liked/saved this post. 
-       Fallback to user ID 1 (demo_user) since Auth is not yet fully implemented. #}
-    {% set current_user_id = current_user.id if current_user is defined and current_user.is_authenticated else 1 %}
+  {# Determine if the current user liked/saved this post #}
+    {% set current_user_id = current_user.id if current_user is defined and current_user.is_authenticated else None %}
     {% set is_liked = post.likes | selectattr("user_id", "equalto", current_user_id) | list | length > 0 %}
     {% set is_saved = post.saved_by | selectattr("user_id", "equalto", current_user_id) | list | length > 0 %}
 

--- a/app/templates/feed.html
+++ b/app/templates/feed.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "components/_post_card.html" import post_card %}
+{% from "components/_post_card.html" import post_card with context %}
 
 {% block title %}Feed | CatchLog{% endblock %}
 

--- a/app/templates/post_detail.html
+++ b/app/templates/post_detail.html
@@ -76,7 +76,7 @@
 
     <!-- Action Bar -->
     <div class="post-card__actions">
-      {% set current_user_id = current_user.id if current_user is defined and current_user.is_authenticated else 1 %}
+      {% set current_user_id = current_user.id if current_user.is_authenticated else None %}
       {% set is_liked = post.likes | selectattr("user_id", "equalto", current_user_id) | list | length > 0 %}
       {% set is_saved = post.saved_by | selectattr("user_id", "equalto", current_user_id) | list | length > 0 %}
 
@@ -135,6 +135,7 @@
   </section>
 
   <!-- Fixed Comment Input Area -->
+  {% if current_user.is_authenticated %}
   <div class="comment-input-area">
     <form id="comment-form" data-post-id="{{ post.id }}">
       <input type="text" id="comment-text" placeholder="Add a comment..."
@@ -144,6 +145,11 @@
       </button>
     </form>
   </div>
+  {% else %}
+  <div class="comment-input-area">
+    <p class="login-prompt"><a href="{{ url_for('login') }}">Log in</a> to leave a comment</p>
+  </div>
+  {% endif %}
 </div>
 {% endblock %}
 

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 {# Import our reusable post card macro #}
-{% from "components/_post_card.html" import post_card %}
+{% from "components/_post_card.html" import post_card with context %}
 
 <div id="profile-container">
   <section id="user-info">


### PR DESCRIPTION
# What
- Fixed a bug where guest (unlogged) users could see the comment input box.
- Fixed a bug where clicking Like/Save as a guest caused a console error (`"<!doctype "... is not valid JSON`).
- Fixed a bug where guest users incorrectly saw User 1's like and save status.

# Why
- The backend `@login_required` was returning an HTML login page instead of a JSON error when API requests were blocked. The frontend tried to read this HTML as JSON and crashed.
- The UI templates were hardcoded to use `user_id = 1` as a fallback for guest users, which is not safe or correct for a real application.
- Unauthenticated users should not be able to interact with posts or see the comment form.

# How
- **Backend**: Added `unauthorized_handler` in `__init__.py`. Now, API routes return a `401 JSON` error, while page routes still redirect to the login page.
- **Frontend**: Added a content-type safety check in `post.js` and `post-card.js`. If the response is not JSON, the user is redirected to `/login`.
- **UI**: Removed the `user_id = 1` fallback in `post_detail.html` and `_post_card.html`. Hid the comment form for guests and added a simple "Log in to leave a comment" link instead.