### PR TITLE
match create post map style

### DIFF
--- a/app/static/js/create-post.js
+++ b/app/static/js/create-post.js
@@ -13,13 +13,20 @@ function initLocationMap() {
 
   const coordinatesEl = document.getElementById("selectedCoordinates");
   const locationInput = document.getElementById("postLocation");
-  const map = L.map(mapEl).setView([-31.9523, 115.8613], 12);
+  const map = L.map(mapEl, {
+    zoomControl: false
+  }).setView([-31.9523, 115.8613], 12);
   let marker = null;
 
-  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-    attribution: "&copy; OpenStreetMap contributors",
-    maxZoom: 19
-  }).addTo(map);
+  L.control.zoom({ position: "topright" }).addTo(map);
+
+  L.tileLayer(
+    "https://tiles.stadiamaps.com/tiles/stamen_toner_dark/{z}/{x}/{y}{r}.png",
+    {
+      attribution: "&copy; OpenStreetMap contributors &copy; Stadia Maps",
+      maxZoom: 20
+    }
+  ).addTo(map);
 
   map.on("click", (event) => {
     selectedLatitude = Number(event.latlng.lat.toFixed(6));


### PR DESCRIPTION
## Summary

- Updated the Create Post location map to use the same Stadia/Stamen dark tile layer as the Map page
- Moved the Leaflet zoom control to the top-right position for consistency
- Kept the existing Create Post map click / marker / coordinate selection behavior unchanged

## Why

This addresses review feedback that the Create Post map should match the visual style of the main Map page.

## Testing

- Ran `node --check app/static/js/create-post.js`

## Related

- Follow-up to PR #61

