### PR TITLE
Add incremental loading to feed

### DIFF
--- a/app/api/posts.py
+++ b/app/api/posts.py
@@ -13,7 +13,14 @@ import re
 import uuid
 from pathlib import Path
 
-from flask import Blueprint, jsonify, request, render_template_string, current_app
+from flask import (
+    Blueprint,
+    current_app,
+    jsonify,
+    render_template,
+    render_template_string,
+    request,
+)
 from flask_login import current_user
 from sqlalchemy import or_
 
@@ -23,6 +30,7 @@ from app.models import Post, PostImage, User
 api_posts_bp = Blueprint("api_posts", __name__)
 
 ALLOWED_CATEGORIES = {"Catch Report", "Gear Review", "Question", "General"}
+FEED_PAGE_SIZE = 10
 DATA_URL_RE = re.compile(r"^data:image/(png|jpe?g|gif|webp);base64,(.+)$", re.I)
 MAX_INLINE_IMAGE_BYTES = 2 * 1024 * 1024
 
@@ -104,15 +112,9 @@ def _serialize_post(post):
     }
 
 
-# ===== CRUD (Felix) =====================================================
-
-
-@api_posts_bp.route("/posts")
-def api_list_posts():
-    """Return database posts in the unified Feed/Create Post JSON shape."""
-    category = request.args.get("category")
-    search = (request.args.get("q") or "").strip()
-
+def build_posts_query(category=None, search=None):
+    """Build the shared Feed/API post query with optional filters."""
+    search = (search or "").strip()
     query = Post.query
 
     if category and category != "All":
@@ -129,8 +131,51 @@ def api_list_posts():
             )
         )
 
-    posts = query.order_by(Post.created_at.desc()).all()
+    return query.order_by(Post.created_at.desc())
+
+
+# ===== CRUD (Felix) =====================================================
+
+
+@api_posts_bp.route("/posts")
+def api_list_posts():
+    """Return database posts in the unified Feed/Create Post JSON shape."""
+    category = request.args.get("category")
+    search = request.args.get("q")
+
+    posts = build_posts_query(category=category, search=search).all()
     return jsonify([_serialize_post(post) for post in posts])
+
+
+@api_posts_bp.route("/posts/feed")
+def api_feed_posts():
+    """Return one page of Feed post HTML for incremental loading."""
+    category = request.args.get("category")
+    search = request.args.get("q")
+    page_number = request.args.get("page", 1, type=int)
+    per_page = request.args.get("per_page", FEED_PAGE_SIZE, type=int)
+
+    page_number = max(page_number, 1)
+    per_page = min(max(per_page, 1), 25)
+
+    page = build_posts_query(category=category, search=search).paginate(
+        page=page_number,
+        per_page=per_page,
+        error_out=False,
+    )
+    html = "".join(
+        render_template("components/_feed_post_item.html", post=post)
+        for post in page.items
+    )
+
+    return jsonify(
+        {
+            "html": html,
+            "page": page.page,
+            "hasMore": page.has_next,
+            "total": page.total,
+        }
+    )
 
 
 @api_posts_bp.route("/posts", methods=["POST"])

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -5,16 +5,26 @@ Owner: Felix-Ma1209
 
 from flask import Blueprint, render_template
 from flask_login import login_required
-from app.models import Post
+from app.api.posts import FEED_PAGE_SIZE, build_posts_query
 
 main_bp = Blueprint("main", __name__)
 
 
 @main_bp.route("/")
 def feed():
-    """Home page — show all posts."""
-    posts = Post.query.order_by(Post.created_at.desc()).all()
-    return render_template("feed.html", posts=posts, active_page="feed")
+    """Home page — show the first page of posts."""
+    page = build_posts_query().paginate(
+        page=1,
+        per_page=FEED_PAGE_SIZE,
+        error_out=False,
+    )
+    return render_template(
+        "feed.html",
+        posts=page.items,
+        has_more_posts=page.has_next,
+        feed_page_size=FEED_PAGE_SIZE,
+        active_page="feed",
+    )
 
 
 @main_bp.route("/create-post")

--- a/app/static/css/feed.css
+++ b/app/static/css/feed.css
@@ -145,7 +145,8 @@
 }
 
 .feed-post-item[hidden],
-.feed-empty-message[hidden] {
+.feed-empty-message[hidden],
+.load-more-btn[hidden] {
   display: none;
 }
 
@@ -156,6 +157,40 @@
   border: 1px dashed var(--color-border-strong);
   border-radius: var(--radius-lg);
   background: var(--color-surface);
+}
+
+.load-more-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  margin: 22px auto 0;
+  padding: 10px 22px;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-primary-dark);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 800;
+  transition:
+    background var(--transition-base),
+    border-color var(--transition-base),
+    box-shadow var(--transition-base),
+    color var(--transition-base);
+}
+
+.load-more-btn:hover,
+.load-more-btn:focus-visible {
+  background: var(--color-primary-light);
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-focus);
+}
+
+.load-more-btn:disabled {
+  cursor: wait;
+  opacity: 0.7;
 }
 
 .feed-card {

--- a/app/static/js/feed.js
+++ b/app/static/js/feed.js
@@ -2,6 +2,7 @@ let currentSearch = "";
 let currentTag = "All";
 let currentPage = 1;
 let isLoading = false;
+let latestFetchId = 0;
 
 const feedContainer = document.getElementById("feedContainer");
 const emptyMessage = document.querySelector(".feed-empty-message");
@@ -24,9 +25,11 @@ function updateEmptyState(total) {
 }
 
 async function loadPosts({ reset = false } = {}) {
-  if (!feedContainer || isLoading) return;
+  if (!feedContainer) return;
+  if (isLoading && !reset) return;
 
   const nextPage = reset ? 1 : currentPage + 1;
+  const currentFetchId = ++latestFetchId;
   const params = new URLSearchParams({
     page: String(nextPage),
     per_page: String(pageSize),
@@ -41,9 +44,7 @@ async function loadPosts({ reset = false } = {}) {
 
   setLoading(true);
   if (reset) {
-    feedContainer.querySelectorAll(".feed-post-item").forEach(item => {
-      item.hidden = true;
-    });
+    feedContainer.style.opacity = "0.5";
   }
 
   try {
@@ -53,6 +54,13 @@ async function loadPosts({ reset = false } = {}) {
     }
 
     const data = await response.json();
+    if (reset && currentFetchId !== latestFetchId) return;
+
+    if (reset) {
+      feedContainer.innerHTML = "";
+      feedContainer.style.opacity = "1";
+    }
+
     feedContainer.insertAdjacentHTML("beforeend", data.html);
 
     currentPage = data.page;
@@ -64,7 +72,10 @@ async function loadPosts({ reset = false } = {}) {
   } catch (error) {
     console.error(error);
   } finally {
-    setLoading(false);
+    if (currentFetchId === latestFetchId) {
+      setLoading(false);
+      feedContainer.style.opacity = "1";
+    }
   }
 }
 

--- a/app/static/js/feed.js
+++ b/app/static/js/feed.js
@@ -1,32 +1,80 @@
 let currentSearch = "";
 let currentTag = "All";
+let currentPage = 1;
+let isLoading = false;
 
-/* Apply both filters together */
-function applyFilters() {
-  const postItems = document.querySelectorAll(".feed-post-item");
-  const emptyMessage = document.querySelector(".feed-empty-message");
-  let visibleCount = 0;
+const feedContainer = document.getElementById("feedContainer");
+const emptyMessage = document.querySelector(".feed-empty-message");
+const loadMoreButton = document.getElementById("loadMorePosts");
+const pageSize = Number(feedContainer?.dataset.pageSize || 10);
+const searchInput = document.getElementById("searchInput");
 
-  postItems.forEach(item => {
-    const matchesTag = currentTag === "All" || item.dataset.category === currentTag;
-    const matchesSearch = !currentSearch || item.dataset.search.includes(currentSearch);
-    const isVisible = matchesTag && matchesSearch;
+function setLoading(isBusy) {
+  isLoading = isBusy;
+  if (loadMoreButton) {
+    loadMoreButton.disabled = isBusy;
+    loadMoreButton.textContent = isBusy ? "Loading..." : "Load more";
+  }
+}
 
-    item.hidden = !isVisible;
-    if (isVisible) visibleCount += 1;
+function updateEmptyState(total) {
+  if (emptyMessage) {
+    emptyMessage.hidden = total !== 0;
+  }
+}
+
+async function loadPosts({ reset = false } = {}) {
+  if (!feedContainer || isLoading) return;
+
+  const nextPage = reset ? 1 : currentPage + 1;
+  const params = new URLSearchParams({
+    page: String(nextPage),
+    per_page: String(pageSize),
   });
 
-  if (emptyMessage) {
-    emptyMessage.hidden = visibleCount !== 0;
+  if (currentSearch) {
+    params.set("q", currentSearch);
+  }
+  if (currentTag !== "All") {
+    params.set("category", currentTag);
+  }
+
+  setLoading(true);
+  if (reset) {
+    feedContainer.querySelectorAll(".feed-post-item").forEach(item => {
+      item.hidden = true;
+    });
+  }
+
+  try {
+    const response = await fetch(`/api/posts/feed?${params.toString()}`);
+    if (!response.ok) {
+      throw new Error("Failed to load posts");
+    }
+
+    const data = await response.json();
+    feedContainer.insertAdjacentHTML("beforeend", data.html);
+
+    currentPage = data.page;
+    updateEmptyState(data.total);
+
+    if (loadMoreButton) {
+      loadMoreButton.hidden = !data.hasMore;
+    }
+  } catch (error) {
+    console.error(error);
+  } finally {
+    setLoading(false);
   }
 }
 
 /* Search */
-const searchInput = document.getElementById("searchInput");
+let searchTimer;
 if (searchInput) {
   searchInput.addEventListener("input", () => {
-    currentSearch = searchInput.value.toLowerCase();
-    applyFilters();
+    currentSearch = searchInput.value.trim();
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => loadPosts({ reset: true }), 250);
   });
 }
 
@@ -37,6 +85,10 @@ tagsEl.forEach(tag => {
     document.querySelector(".tag.active")?.classList.remove("active");
     tag.classList.add("active");
     currentTag = tag.innerText;
-    applyFilters();
+    loadPosts({ reset: true });
   });
 });
+
+if (loadMoreButton) {
+  loadMoreButton.addEventListener("click", () => loadPosts());
+}

--- a/app/templates/components/_feed_post_item.html
+++ b/app/templates/components/_feed_post_item.html
@@ -1,0 +1,8 @@
+{% from "components/_post_card.html" import post_card with context %}
+
+<div
+  class="feed-post-item"
+  data-category="{{ post.category or 'General' }}"
+>
+  {{ post_card(post) }}
+</div>

--- a/app/templates/feed.html
+++ b/app/templates/feed.html
@@ -1,6 +1,4 @@
 {% extends "base.html" %}
-{% from "components/_post_card.html" import post_card with context %}
-
 {% block title %}Feed | CatchLog{% endblock %}
 
 {% block styles %}
@@ -37,19 +35,24 @@
     </div>
 
     <!-- Feed posts -->
-    <div class="feed-container" id="feedContainer">
+    <div
+      class="feed-container"
+      id="feedContainer"
+      data-page-size="{{ feed_page_size }}"
+    >
       {% for post in posts %}
-        <div
-          class="feed-post-item"
-          data-category="{{ post.category or 'General' }}"
-          data-search="{{ (post.content ~ ' ' ~ (post.user.username if post.user else '') ~ ' ' ~ (post.species or '') ~ ' ' ~ (post.location_name or '')) | lower }}"
-        >
-          {{ post_card(post) }}
-        </div>
-      {% else %}
-        <p class="feed-empty-message">No posts found</p>
+        {% include "components/_feed_post_item.html" %}
       {% endfor %}
     </div>
+    <p class="feed-empty-message" {% if posts %}hidden{% endif %}>No posts found</p>
+    <button
+      type="button"
+      class="load-more-btn"
+      id="loadMorePosts"
+      {% if not has_more_posts %}hidden{% endif %}
+    >
+      Load more
+    </button>
   </div>
 </div>
 {% endblock %}

--- a/tests/test_create_post_feed.py
+++ b/tests/test_create_post_feed.py
@@ -1,6 +1,9 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from app import create_app, db
+from app.api.posts import FEED_PAGE_SIZE
 from app.models import Post, User
 from config import TestConfig
 
@@ -147,3 +150,57 @@ def test_feed_renders_database_posts(client, app):
     assert b"Feed visible pytest post" in response.data
     assert b"Bream" in response.data
     assert b"Canning River" in response.data
+
+
+def test_feed_route_renders_only_first_page(client, app):
+    with app.app_context():
+        user = User.query.filter_by(username="tester").one()
+        base_time = datetime(2026, 5, 15, tzinfo=timezone.utc)
+        for index in range(FEED_PAGE_SIZE + 2):
+            db.session.add(Post(
+                user_id=user.id,
+                content=f"Paged feed post {index}",
+                category="General",
+                created_at=base_time + timedelta(minutes=index),
+            ))
+        db.session.commit()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b"Paged feed post 11" in response.data
+    assert b"Paged feed post 1" in response.data
+    assert b"Paged feed post 0" not in response.data
+    assert b'id="loadMorePosts"' in response.data
+
+
+def test_feed_incremental_endpoint_filters_and_paginates(client, app):
+    with app.app_context():
+        user = User.query.filter_by(username="tester").one()
+        base_time = datetime(2026, 5, 15, tzinfo=timezone.utc)
+        posts = [
+            ("Recent trout catch", "Catch Report", "Trout"),
+            ("Older trout catch", "Catch Report", "Trout"),
+            ("Trout rod review", "Gear Review", "Trout"),
+            ("General bream catch", "General", "Bream"),
+        ]
+        for index, (content, category, species) in enumerate(posts):
+            db.session.add(Post(
+                user_id=user.id,
+                content=content,
+                category=category,
+                species=species,
+                created_at=base_time + timedelta(minutes=index),
+            ))
+        db.session.commit()
+
+    response = client.get(
+        "/api/posts/feed?q=trout&category=Catch+Report&page=1&per_page=1"
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["hasMore"] is True
+    assert data["total"] == 2
+    assert "Older trout catch" in data["html"]
+    assert "Trout rod review" not in data["html"]


### PR DESCRIPTION
## Summary
- Limit the Feed initial render to the first page of posts
- Add a Load more button for incremental loading
- Keep search and category filtering working through the paginated feed endpoint
- Add tests for initial pagination and filtered incremental loading

## Related
Closes #76

## Tests
- python -m pytest tests/test_create_post_feed.py tests/test_selenium_create_post_feed.py