### PR TITLE
fix: require secret key from environment

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,13 +1,24 @@
 import os
+from dotenv import load_dotenv
 
 basedir = os.path.abspath(os.path.dirname(__file__))
+
+# Load local environment variables from .env before Config reads them.
+load_dotenv(os.path.join(basedir, ".env"))
+
 os.makedirs(os.path.join(basedir, "instance"), exist_ok=True)
 
 
 class Config:
     """Application configuration — reads secrets from environment variables."""
 
-    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-fallback-key-change-me")
+    SECRET_KEY = os.environ.get("SECRET_KEY")
+
+    if not SECRET_KEY:
+        raise RuntimeError(
+            "SECRET_KEY environment variable is not set. "
+            "Please create a .env file and define SECRET_KEY before running the app."
+        )
 
     SQLALCHEMY_DATABASE_URI = os.environ.get(
         "DATABASE_URL", "sqlite:///" + os.path.join(basedir, "instance", "catchlog.db")
@@ -22,5 +33,6 @@ class TestConfig(Config):
     """Overrides for pytest — uses in-memory SQLite."""
 
     TESTING = True
+    SECRET_KEY = "test-secret-key"
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     WTF_CSRF_ENABLED = False


### PR DESCRIPTION
## Description

Removed the hardcoded fallback value for `SECRET_KEY` so the app requires the secret key to be configured through environment variables.

## Changes

- Removed the default fallback secret key from `config.py`
- Added a clear runtime error when `SECRET_KEY` is missing
- Loaded local environment variables from `.env`
- Kept a fixed test secret key only in `TestConfig`

## Testing

- Confirmed the app fails clearly when `SECRET_KEY` is missing
- Confirmed the app runs when `SECRET_KEY` is defined in `.env`