### PR TITLE
Fix sidebar stale interactions

### DIFF
--- a/app/api/posts.py
+++ b/app/api/posts.py
@@ -278,7 +278,7 @@ def api_map_posts():
     )
 
     macro_template = """
-    {% from 'components/_post_card.html' import post_card %}
+    {% from 'components/_post_card.html' import post_card with context %}
     {{ post_card(post, variant='compact') }}
     """
 

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -120,11 +120,49 @@ async function loadMapPosts() {
   }
 }
 
+async function refreshMapPostsAndSidebar() {
+  const wasSidebarOpen = sidebar.classList.contains("open");
+
+  const previouslyOpenPostIds = lastOpenedGroup
+    ? lastOpenedGroup.map(post => String(post.id))
+    : [];
+
+  await loadMapPosts();
+
+  if (!wasSidebarOpen || previouslyOpenPostIds.length === 0) {
+    return;
+  }
+
+  const refreshedGroup = posts.filter(post =>
+    previouslyOpenPostIds.includes(String(post.id))
+  );
+
+  if (refreshedGroup.length > 0) {
+    lastOpenedGroup = refreshedGroup;
+    selectedPostId = refreshedGroup[0].id;
+    openSidebarWithUI(refreshedGroup);
+  }
+}
+
 map.on("zoomend", renderMarkersDynamic);
 
 // Click map → close
 map.on("click", () => {
   closeSidebarWithUI();
+});
+
+document.addEventListener("postInteractionChanged", async (event) => {
+  const changedPostId = String(event.detail.postId);
+
+  const changedPostIsOnMap = posts.some(post =>
+    String(post.id) === changedPostId
+  );
+
+  if (!changedPostIsOnMap) {
+    return;
+  }
+
+  await refreshMapPostsAndSidebar();
 });
 
 loadMapPosts();

--- a/app/static/js/post-card.js
+++ b/app/static/js/post-card.js
@@ -130,6 +130,16 @@ document.addEventListener("DOMContentLoaded", () => {
         }));
       }
     }
+    // Notify parent pages, such as the map sidebar, that this post's interaction
+    // state changed so they can refresh any cached post-card HTML.
+    button.dispatchEvent(new CustomEvent("postInteractionChanged", {
+      bubbles: true,
+      detail: {
+        type,
+        postId: button.dataset.postId,
+        ...data
+      }
+    }));
   }
 
   async function deletePost(button) {


### PR DESCRIPTION
# What

This PR fixes stale interaction state in the map sidebar post cards.

Previously, when a user liked or saved a post from the map sidebar, the database update worked, but the map sidebar could still show outdated like/save state after refreshing or re-rendering the sidebar.

# Why

The map page stores post cards as pre-rendered HTML from `/api/posts/map`. After a like/save action, `post-card.js` updated the clicked button in the current DOM, but the map page still had old cached post-card HTML.

This caused the sidebar to sometimes revert the heart/bookmark icon back to the old state after the map posts were refreshed.

# How

- Added a `postInteractionChanged` custom event in `post-card.js` after successful like/save UI updates.
- Added a listener in `map.js` so the map page refreshes its cached post data when a post interaction changes.
- Updated the map post-card macro import to use `with context`, so the compact map sidebar cards correctly receive `current_user` context when rendered through `render_template_string`.
- This allows `/api/posts/map` to return the correct liked/saved button state for the current user.

# Testing

Manually tested on the map page:

- Opened a post from a map marker.
- Liked/unliked a post from the sidebar.
- Confirmed the like count updates.
- Confirmed the heart icon no longer immediately reverts.
- Confirmed reopening/re-rendering the sidebar keeps the correct interaction state.
- Confirmed `/api/posts/map` returns the correct `fa-solid` / `fa-regular` icon state after interaction.