### PR TITLE
Map page tests, documentations and final check

### DIFF
--- a/app/api/posts.py
+++ b/app/api/posts.py
@@ -269,6 +269,8 @@ def api_delete_post(post_id):
 def api_map_posts():
     """Return posts that have valid location data for the map page."""
 
+    # Map markers should only represent visible posts with coordinates.
+    # Posts without latitude/longitude cannot be placed on the Leaflet map.
     posts = (
         Post.query
         .filter(
@@ -280,6 +282,8 @@ def api_map_posts():
         .all()
     )
 
+    # Reuse the shared post-card macro instead of rebuilding sidebar HTML in JS.
+    # This keeps the map sidebar consistent with Feed/Profile post cards.
     macro_template = """
     {% from 'components/_post_card.html' import post_card with context %}
     {{ post_card(post, variant='compact') }}
@@ -290,6 +294,7 @@ def api_map_posts():
     for post in posts:
         html_string = render_template_string(macro_template, post=post)
 
+        # Send coordinates for Leaflet and compact HTML for the sidebar.
         result.append({
             "id": str(post.id),
             "latitude": post.latitude,

--- a/app/static/css/map.css
+++ b/app/static/css/map.css
@@ -319,3 +319,23 @@ body {
 .like-btn.liked {
   color: #e0245e;
 }
+
+/* Mobile map layout: keep sidebar usable on small screens. */
+@media (max-width: 600px) {
+  #sidebar {
+    width: 85vw;
+    left: -85vw;
+  }
+
+  #sidebar.open + #sidebar-tab {
+    left: 85vw;
+  }
+
+  .sidebar-feed {
+    padding: 8px;
+  }
+
+  .carousel-slide {
+    height: 200px;
+  }
+}

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -47,9 +47,17 @@ L.tileLayer(
 
 // Sidebar
 
+// Tracks the posts currently loaded from the backend.
+// These are used for marker rendering and sidebar refreshes.
 let posts = [];
+
+// Stores the last marker group opened by the user.
+// This allows the sidebar tab to reopen the previous group after closing.
 let lastOpenedGroup = null;
+
+// Tracks the selected post so the matching marker can be highlighted.
 let selectedPostId = null;
+
 
 const sidebar = document.getElementById("sidebar");
 
@@ -82,6 +90,9 @@ function renderMarkersDynamic() {
 
   const zoom = map.getZoom();
 
+  // Use smaller grouping distances at higher zoom levels.
+  // When zoomed in, nearby posts should separate into individual markers.
+  // When zoomed out, nearby posts are grouped to reduce marker clutter.
   const threshold =
     zoom >= 15 ? 30 :
     zoom >= 13 ? 50 :
@@ -98,6 +109,8 @@ function renderMarkersDynamic() {
   }, selectedPostId);
 }
 
+// Load only posts with valid latitude/longitude from the backend.
+// The backend returns pre-rendered compact post-card HTML for the sidebar.
 async function loadMapPosts() {
   try {
     const response = await fetch("/api/posts/map");
@@ -120,6 +133,8 @@ async function loadMapPosts() {
   }
 }
 
+// Refresh map data after likes/saves/comments change.
+// This prevents the sidebar from reusing old cached post-card HTML.
 async function refreshMapPostsAndSidebar() {
   const wasSidebarOpen = sidebar.classList.contains("open");
 
@@ -151,6 +166,8 @@ map.on("click", () => {
   closeSidebarWithUI();
 });
 
+// post-card.js dispatches this event after a like/save interaction.
+// The map listens for it because sidebar cards are loaded as cached HTML.
 document.addEventListener("postInteractionChanged", async (event) => {
   const changedPostId = String(event.detail.postId);
 

--- a/app/static/js/marker.js
+++ b/app/static/js/marker.js
@@ -1,3 +1,5 @@
+// Create a custom Leaflet marker.
+// Single posts show a fish icon; grouped posts show the number of posts.
 function createMarkerIcon(count, isActive = false) {
   const content = count > 1
     ? `<span class="marker-count">${count}</span>`
@@ -15,7 +17,8 @@ function createMarkerIcon(count, isActive = false) {
   });
 }
 
-// Group Rendering
+// Create a custom Leaflet marker.
+// Single posts show a fish icon; grouped posts show the number of posts.
 export function renderMarkers(layer, groups, onMarkerClick, selectedPostId = null) {
   groups.forEach(group => {
     const { latitude, longitude } = group[0];

--- a/app/static/js/sidebar.js
+++ b/app/static/js/sidebar.js
@@ -1,3 +1,5 @@
+// Open the sidebar and insert the compact post-card HTML returned by the backend.
+// This keeps map sidebar cards visually consistent with feed/profile post cards.
 export function openSidebar(group, sidebar, closeSidebar) {
   sidebar.innerHTML = `
     <div class="sidebar-header">
@@ -12,10 +14,12 @@ export function openSidebar(group, sidebar, closeSidebar) {
   sidebar.classList.add("open");
 }
 
+// Closes the Sidebar
 export function closeSidebar(sidebar) {
   sidebar.classList.remove("open");
 }
 
+// Show an initial helper message before the user clicks a map marker.
 export function showEmptySidebar(sidebar, closeSidebar) {
   sidebar.innerHTML = `
     <div class="sidebar-header">

--- a/app/static/js/utils.js
+++ b/app/static/js/utils.js
@@ -1,3 +1,5 @@
+// Haversine distance calculation.
+// Returns the approximate distance in metres between two latitude/longitude points.
 export function getDistance(p1, p2) {
   const R = 6371000;
   const toRad = x => x * Math.PI / 180;
@@ -15,12 +17,16 @@ export function getDistance(p1, p2) {
 }
 
 // Grouping logic
+// Groups posts that are geographically close together.
+// The threshold is in metres and changes depending on map zoom level.
 export function groupPosts(posts, threshold = 50) {
   const groups = [];
 
   posts.forEach(post => {
     let found = false;
 
+    // Compare this post with the first post in each existing group.
+    // If it is close enough, add it to that group.
     for (let group of groups) {
       const dist = getDistance(
         {

--- a/tests/test_map_api.py
+++ b/tests/test_map_api.py
@@ -1,0 +1,102 @@
+import pytest
+
+from app import create_app, db
+from app.models import Post, User
+from config import TestConfig
+
+
+@pytest.fixture()
+def app():
+    test_app = create_app(TestConfig)
+
+    with test_app.app_context():
+        db.create_all()
+
+        user = User(username="maptester", email="maptester@example.com")
+        user.set_password("password123")
+        db.session.add(user)
+        db.session.commit()
+
+        located_post = Post(
+            user_id=user.id,
+            content="Visible map post",
+            category="Catch Report",
+            species="Bream",
+            location_name="Swan River",
+            latitude=-31.9523,
+            longitude=115.8613,
+        )
+
+        no_location_post = Post(
+            user_id=user.id,
+            content="Post without coordinates",
+            category="General",
+            latitude=None,
+            longitude=None,
+        )
+
+        deleted_location_post = Post(
+            user_id=user.id,
+            content="Deleted map post",
+            category="Catch Report",
+            latitude=-31.95,
+            longitude=115.86,
+            is_deleted=True,
+        )
+
+        db.session.add_all([
+            located_post,
+            no_location_post,
+            deleted_location_post,
+        ])
+        db.session.commit()
+
+    yield test_app
+
+    with test_app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_map_api_returns_200(client):
+    response = client.get("/api/posts/map")
+
+    assert response.status_code == 200
+
+
+def test_map_api_returns_only_posts_with_location_data(client):
+    response = client.get("/api/posts/map")
+
+    assert response.status_code == 200
+
+    data = response.get_json()
+    contents = [post["html"] for post in data]
+
+    assert len(data) == 1
+    assert "Visible map post" in contents[0]
+    assert "Post without coordinates" not in contents[0]
+    assert "Deleted map post" not in contents[0]
+
+
+def test_map_api_response_contains_required_map_fields(client):
+    response = client.get("/api/posts/map")
+
+    assert response.status_code == 200
+
+    data = response.get_json()
+    post = data[0]
+
+    assert "id" in post
+    assert "latitude" in post
+    assert "longitude" in post
+    assert "html" in post
+
+    assert post["latitude"] == -31.9523
+    assert post["longitude"] == 115.8613
+    assert isinstance(post["html"], str)
+    assert len(post["html"]) > 0


### PR DESCRIPTION
# Summary

Added map-specific API tests, explanatory comments for the map page code, and a small responsive CSS adjustment for the map sidebar.

# What changed

- Added tests for `/api/posts/map`
- Verified that the map API only returns posts with latitude and longitude
- Verified that deleted posts are excluded from map results
- Verified that each map API result includes `id`, `latitude`, `longitude`, and `html`
- Added comments explaining map post loading, zoom-based marker grouping, sidebar reopen state, and stale sidebar refresh behaviour
- Added comments explaining backend map API rendering of compact post-card HTML
- Added a small mobile CSS adjustment so the map sidebar remains usable on narrow screens

# Notes

The documentation comments do not change application behaviour. The CSS change only adjusts sidebar sizing on small screens.

# Testing

Run:

```python
python -m pytest tests/test_map_api.py